### PR TITLE
fix: use 'husky || true' in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"engineStrict": true,
 	"scripts": {
-		"prepare": "husky",
+		"prepare": "husky || true",
 		"git:pre-commit": "npm run git:lint-staged && npm run git:test-staged",
 		"git:commit-msg": "commitlint --config commitlint.config.cjs --edit",
 		"git:lint-staged": "npm run test:lint",


### PR DESCRIPTION
## Summary
- Change `"prepare": "husky"` to `"prepare": "husky || true"`
- Prevents `npm ci` from failing in environments where husky isn't installed (e.g. production Docker builds, CI steps using `--omit=dev`)

## Test plan
- [ ] Verify `npm ci` still installs husky hooks in dev environments
- [ ] Verify `npm ci --omit=dev` no longer fails on missing husky