### PR TITLE
chore: use npm run test:lint in test-lint workflow

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -28,4 +28,4 @@ jobs:
           npm ci
       - name: Linting
         run: |
-          ./node_modules/.bin/biome ci --no-errors-on-unmatched
+          npm run test:lint


### PR DESCRIPTION
## Summary
- Replace `./node_modules/.bin/biome ci --no-errors-on-unmatched` with `npm run test:lint`
- Keeps the lint command centralized in package.json — CI uses the same script maintainers run locally

## Test plan
- [ ] Verify `Tests (lint)` status check still passes on PRs